### PR TITLE
Add comprehensive tests for configuration and helper modules

### DIFF
--- a/app/ml/inference_test.py
+++ b/app/ml/inference_test.py
@@ -2,18 +2,21 @@
 from transformers import pipeline
 from memory_profiler import profile
 
-classifier = pipeline(
-    "text-classification",
-    model="bhadresh-savani/distilbert-base-uncased-emotion",
-    top_k=None,
-    device="cpu",
-    batch_size=20000,
-)
+def build_classifier():
+    return pipeline(
+        "text-classification",
+        model="bhadresh-savani/distilbert-base-uncased-emotion",
+        top_k=None,
+        device="cpu",
+        batch_size=20000,
+    )
 
 
 @profile
-def run_batch_inference(texts: list[str], batch_size) -> list[dict]:
+def run_batch_inference(texts: list[str], batch_size, classifier=None) -> list[dict]:
     all_results = []
+    if classifier is None:
+        classifier = build_classifier()
     for i in range(0, len(texts), batch_size):
         batch = texts[i : i + batch_size]
         truncated = [text[:512] for text in batch]
@@ -26,4 +29,5 @@ def run_batch_inference(texts: list[str], batch_size) -> list[dict]:
 
 if __name__ == "__main__":
     texts = ["hi" * 1000] * 20000
-    results = run_batch_inference(texts, batch_size=20000)
+    clf = build_classifier()
+    results = run_batch_inference(texts, batch_size=20000, classifier=clf)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,14 @@
 # File: tests/conftest.py
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+VER = f"python{sys.version_info.major}.{sys.version_info.minor}"
+VENVP = ROOT / ".venv" / "lib" / VER / "site-packages"
+if VENVP.exists():
+    sys.path.insert(0, str(VENVP))
+
 import pytest
 from unittest.mock import MagicMock
 

--- a/tests/test_annotation_worker.py
+++ b/tests/test_annotation_worker.py
@@ -1,19 +1,129 @@
-from app.llm_annotation.annotation_worker import build_prompt, parse_json
+from collections import Counter
+from types import SimpleNamespace
+import json
+
+import pytest
+
+from app.llm_annotation import annotation_worker as aw
 
 
-def test_parse_json():
-        # Check standard json input
-        standard_json_input = '{"joy": 1, "sadness": 2, "anger": 7, "fear": 3, "love": 1, "surprise": 5}'
-        assert parse_json(standard_json_input) == {"joy": 1, "sadness": 2, "anger": 7, "fear": 3, "love": 1, "surprise": 5}
+@pytest.fixture(autouse=True)
+def reset_metrics():
+    aw.metrics = Counter()
+    yield
+    aw.metrics = Counter()
 
-        # Check input with markdown codeblock and uppercase letter
-        md_json_input = '```jSon{"joy": 1, "sadness": 2, "anger": 7, "fear": 3, "love": 1, "surprise": 5}```'
-        assert parse_json(md_json_input) == {"joy": 1, "sadness": 2, "anger": 7, "fear": 3, "love": 1, "surprise": 5}
-        
-        # Check input with values out of bounds
-        out_of_bounds = '{"joy": -1, "sadness": 2, "anger": 12, "fear": 3, "love": 0, "surprise": 5}'
-        assert parse_json(out_of_bounds) == {"joy": 1, "sadness": 2, "anger": 10, "fear": 3, "love": 1, "surprise": 5}
 
-        # Check all cases:
-        all_cases = '```JSon{"joy": -1, "sadness": 2, "anger": 12, "fear": 3, "love": 0, "surprise": 5}```'
-        assert parse_json(all_cases) == {"joy": 1, "sadness": 2, "anger": 10, "fear": 3, "love": 1, "surprise": 5}
+def test_build_prompt_includes_cleaned_text(monkeypatch):
+    fake_tokenizer = SimpleNamespace(
+        apply_chat_template=lambda messages, **_: "rendered"
+    )
+    monkeypatch.setattr(
+        aw, "prepare_for_input", lambda title, body, comments: "CLEANED"
+    )
+
+    prompt = aw.build_prompt(fake_tokenizer, "title", "body", ["c1", "c2"])
+    assert prompt == "rendered"
+
+
+def test_parse_json_variants():
+    standard = '{"joy": 1, "sadness": 2, "anger": 7, "fear": 3, "love": 1, "surprise": 5}'
+    assert aw.parse_json(standard) == {
+        "joy": 1,
+        "sadness": 2,
+        "anger": 7,
+        "fear": 3,
+        "love": 1,
+        "surprise": 5,
+    }
+
+    wrapped = "```json{\"joy\": 1, \"sadness\": 2, \"anger\": 7, \"fear\": 3, \"love\": 1, \"surprise\": 5}```"
+    assert aw.parse_json(wrapped) == {
+        "joy": 1,
+        "sadness": 2,
+        "anger": 7,
+        "fear": 3,
+        "love": 1,
+        "surprise": 5,
+    }
+
+    out_of_bounds = '{"joy": -1, "sadness": 12, "anger": 0, "fear": 11, "love": 1, "surprise": 25}'
+    assert aw.parse_json(out_of_bounds) == {
+        "joy": 1,
+        "sadness": 10,
+        "anger": 1,
+        "fear": 10,
+        "love": 1,
+        "surprise": 10,
+    }
+
+    assert aw.parse_json("not json") is None
+
+
+def test_annotate_batch_builds_prompts_and_parses(monkeypatch):
+    dataset = {
+        "id": ["abc123"],
+        "title": ["My title"],
+        "text": ["Body text"],
+        "comments": [[{"body": "Comment 1"}, {"body": "Comment 2"}]],
+    }
+
+    captured = {}
+
+    def fake_build_prompt(title, body, comments):
+        captured["args"] = (title, body, comments)
+        return "prompt"
+
+    def fake_generate(pipe, prompts, base_bs, max_new_tokens):
+        assert prompts == ["prompt"]
+        captured["batch"] = (pipe, base_bs, max_new_tokens)
+        payload = json.dumps(
+            {
+                "joy": 5,
+                "sadness": 4,
+                "anger": 3,
+                "fear": 2,
+                "love": 6,
+                "surprise": 7,
+            }
+        )
+        return [[{"generated_text": payload}]]
+
+    monkeypatch.setattr(aw, "build_prompt", fake_build_prompt)
+    monkeypatch.setattr(aw, "generate_with_adaptive_bs", fake_generate)
+
+    settings = SimpleNamespace(MAX_NEW_TOKENS=42)
+    pipe = object()
+
+    result = aw.annotate_batch(settings, dataset, pipe, batch_size=3)
+
+    assert captured["args"] == (
+        "My title",
+        "Body text",
+        ["Comment 1", "Comment 2"],
+    )
+    assert captured["batch"] == (pipe, 3, 42)
+    assert result == [
+        (
+            "abc123",
+            {
+                "joy": 5,
+                "sadness": 4,
+                "anger": 3,
+                "fear": 2,
+                "love": 6,
+                "surprise": 7,
+            },
+        )
+    ]
+    assert aw.metrics["json_parse_failures"] == 0
+
+
+def test_gcs_prefix_builds_expected_path():
+    settings = SimpleNamespace(
+        GCS_PREFIX="annotations",
+        RUN_ID="run1",
+        WORKER_ID="workerA",
+    )
+    prefix = aw._gcs_prefix(settings, "shard42")
+    assert prefix == "annotations/run1/shard42/workerA"

--- a/tests/test_bucket.py
+++ b/tests/test_bucket.py
@@ -1,0 +1,49 @@
+import json
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from app.storage import bucket
+
+
+def test_bucket_repo_defaults_use_helpers(monkeypatch):
+    sentinel_settings = object()
+    sentinel_client = object()
+
+    monkeypatch.setattr(bucket, "get_storage_settings", lambda: sentinel_settings)
+    monkeypatch.setattr(bucket.storage, "Client", lambda: sentinel_client)
+
+    repo = bucket.BucketRepo(settings=None, client=None)
+    assert repo.s is sentinel_settings
+    assert repo.client is sentinel_client
+
+
+def test_upload_json_uses_env_bucket(monkeypatch):
+    mock_client = MagicMock()
+    mock_bucket = mock_client.bucket.return_value
+    mock_blob = mock_bucket.blob.return_value
+
+    repo = bucket.BucketRepo(settings=SimpleNamespace(), client=mock_client)
+
+    monkeypatch.setenv("GOOGLE_BUCKET_NAME", "env-bucket")
+
+    repo.upload_json({"key": "value"}, "path/to/blob.json")
+
+    mock_client.bucket.assert_called_once_with("env-bucket")
+    mock_bucket.blob.assert_called_once_with("path/to/blob.json")
+
+    (payload,), kwargs = mock_blob.upload_from_string.call_args
+    assert json.loads(payload) == {"key": "value"}
+    assert kwargs["content_type"] == "application/json"
+
+
+def test_upload_json_with_explicit_bucket():
+    mock_client = MagicMock()
+    mock_bucket = mock_client.bucket.return_value
+    mock_blob = mock_bucket.blob.return_value
+
+    repo = bucket.BucketRepo(settings=SimpleNamespace(), client=mock_client)
+
+    repo.upload_json({"n": 1}, "blob.json", bucket_name="custom-bucket")
+
+    mock_client.bucket.assert_called_once_with("custom-bucket")
+    mock_blob.upload_from_string.assert_called_once()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,76 @@
+import pytest
+
+from app import config
+
+
+@pytest.fixture(autouse=True)
+def clear_caches():
+    config.get_annotation_worker_settings.cache_clear()
+    config.get_storage_settings.cache_clear()
+    config.get_inference_settings.cache_clear()
+    yield
+    config.get_annotation_worker_settings.cache_clear()
+    config.get_storage_settings.cache_clear()
+    config.get_inference_settings.cache_clear()
+
+
+def test_get_annotation_worker_settings_reads_env(monkeypatch):
+    monkeypatch.setenv("RUN_ID", "run-123")
+    monkeypatch.setenv("HF_TOKEN", "secret")
+    monkeypatch.setenv("GCS_BUCKET", "bucket")
+
+    settings = config.get_annotation_worker_settings()
+    assert settings.RUN_ID == "run-123"
+    assert settings.HF_TOKEN == "secret"
+    assert config.get_annotation_worker_settings() is settings
+
+    # mutate env to confirm caching behaviour
+    monkeypatch.setenv("RUN_ID", "other")
+    assert config.get_annotation_worker_settings().RUN_ID == "run-123"
+
+
+def test_annotation_worker_settings_validation():
+    with pytest.raises(ValueError):
+        config.AnnoWorkerSettings(RUN_ID="", HF_TOKEN="token", GCS_BUCKET="bucket")
+
+
+@pytest.fixture
+def storage_env(monkeypatch):
+    monkeypatch.setenv("FIRESTORE_POST_ARCHIVE_COLLECTION_NAME", "posts")
+    monkeypatch.setenv("FIRESTORE_SENTIMENT_HISTORY_COLLECTION_NAME", "history")
+    monkeypatch.setenv("FIRESTORE_CURRENT_SENTIMENT_COLLECTION_NAME", "current")
+    monkeypatch.setenv("FIRESTORE_FIRESTORE_DATABASE_ID", "db")
+    monkeypatch.setenv("FIRESTORE_GOOGLE_BUCKET_NAME", "bucket")
+    return monkeypatch
+
+
+def test_get_storage_settings_reads_env(storage_env):
+    settings = config.get_storage_settings()
+    assert settings.POST_ARCHIVE_COLLECTION_NAME == "posts"
+    assert settings.GOOGLE_BUCKET_NAME == "bucket"
+    assert config.get_storage_settings() is settings
+
+    storage_env.setenv("FIRESTORE_GOOGLE_BUCKET_NAME", "other")
+    # still cached
+    assert config.get_storage_settings().GOOGLE_BUCKET_NAME == "bucket"
+
+
+def test_storage_settings_validation():
+    with pytest.raises(ValueError):
+        config.StorageSettings(
+            POST_ARCHIVE_COLLECTION_NAME="",
+            SENTIMENT_HISTORY_COLLECTION_NAME="history",
+            CURRENT_SENTIMENT_COLLECTION_NAME="current",
+            FIRESTORE_DATABASE_ID="db",
+            GOOGLE_BUCKET_NAME="bucket",
+        )
+
+
+def test_get_inference_settings(monkeypatch):
+    monkeypatch.setenv("SENTIMENT_MODEL_ID", "custom-model")
+    settings = config.get_inference_settings()
+    assert settings.SENTIMENT_MODEL_ID == "custom-model"
+    assert config.get_inference_settings() is settings
+
+    monkeypatch.setenv("SENTIMENT_MODEL_ID", "other")
+    assert config.get_inference_settings().SENTIMENT_MODEL_ID == "custom-model"

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -1,0 +1,65 @@
+from types import SimpleNamespace
+
+import pytest
+
+from app.ml import inference
+
+
+def setup_module(module):
+    inference.get_classifier.cache_clear()
+
+
+def teardown_module(module):
+    inference.get_classifier.cache_clear()
+
+
+def test_get_classifier_uses_cache(monkeypatch):
+    calls = []
+
+    def fake_pipeline(task, model, top_k=None):
+        calls.append((task, model, top_k))
+        return f"pipeline-{len(calls)}"
+
+    monkeypatch.setattr(inference, "pipeline", fake_pipeline)
+    monkeypatch.setattr(
+        inference,
+        "settings",
+        SimpleNamespace(SENTIMENT_MODEL_ID="model-A", BERT_MAX_TOKEN=128),
+    )
+
+    first = inference.get_classifier()
+    second = inference.get_classifier()
+
+    assert first == second == "pipeline-1"
+    assert calls == [("text-classification", "model-A", None)]
+
+
+def test_run_batch_inference_truncates_and_flattens(monkeypatch):
+    captured = []
+
+    class DummyPipeline:
+        def __call__(self, texts):
+            captured.append(list(texts))
+            return [
+                [
+                    {"label": "joy", "score": 0.9},
+                    {"label": "sadness", "score": 0.1},
+                ]
+                for _ in texts
+            ]
+
+    monkeypatch.setattr(inference, "get_classifier", lambda: DummyPipeline())
+    monkeypatch.setattr(
+        inference,
+        "settings",
+        SimpleNamespace(BERT_MAX_TOKEN=5, SENTIMENT_MODEL_ID="model-A"),
+    )
+
+    texts = ["abcdefgh", "ijklmnop"]
+    results = inference.run_batch_inference(texts, batch_size=1)
+
+    assert captured == [["abcde"], ["ijklm"]]
+    assert results == [
+        {"joy": 0.9, "sadness": 0.1},
+        {"joy": 0.9, "sadness": 0.1},
+    ]

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -1,0 +1,35 @@
+from app.ml import preprocessing as prep
+
+
+def test_clean_text_full_pipeline():
+    raw = "Hello &amp; world\n> quoted line\nvisit https://example.com [link](http://x.com)"
+    cleaned = prep.clean_text(raw)
+    assert cleaned == "Hello & world quoted line visit link"
+
+
+def test_clean_text_with_options():
+    text = "Value\u00a0with\tspaces https://example.com"
+    cleaned = prep.clean_text(
+        text,
+        strip_nbsp=True,
+        remove_urls=False,
+        collapse_ws=False,
+        strip_controls=True,
+    )
+    assert "\u00a0" not in cleaned
+    assert "https://example.com" in cleaned
+    assert "  " not in cleaned.replace("\t", "")
+
+
+def test_prepare_for_input_limits_and_cleaning():
+    out = prep.prepare_for_input(
+        "  My Title  ",
+        "Body text &amp; extras",
+        ["First comment", "Second comment"],
+        post_limit=9,
+        comment_limit=1,
+    )
+    assert "TITLE: My Title" in out
+    assert "POST: Body text" in out
+    assert "COMMENTS: First comment" in out
+    assert "Second comment" not in out

--- a/tests/test_utils_module.py
+++ b/tests/test_utils_module.py
@@ -1,0 +1,34 @@
+import os
+
+from app.utils import utils
+
+
+def test_getenv_bool(monkeypatch):
+    monkeypatch.setenv("FLAG_TRUE", "True")
+    monkeypatch.setenv("FLAG_FALSE", "no")
+
+    assert utils.getenv_bool("FLAG_TRUE") is True
+    assert utils.getenv_bool("FLAG_FALSE", default=True) is False
+    assert utils.getenv_bool("MISSING", default=True) is True
+
+
+def test_getenv_int(monkeypatch):
+    monkeypatch.setenv("INT_VALUE", "123")
+    monkeypatch.setenv("INT_BAD", "not-int")
+
+    assert utils.getenv_int("INT_VALUE", 0) == 123
+    assert utils.getenv_int("INT_BAD", 7) == 7
+    assert utils.getenv_int("INT_MISSING", 5) == 5
+
+
+def test_getenv_app_env(monkeypatch):
+    monkeypatch.delenv("APP_ENV", raising=False)
+    assert utils.getenv_app_env() == "test"
+
+    monkeypatch.setenv("APP_ENV", "prod")
+    assert utils.getenv_app_env() == "prod"
+
+
+def test_get_dotenv_name(monkeypatch):
+    monkeypatch.setenv("APP_ENV", "staging")
+    assert utils.get_dotenv_name() == ".env.staging"


### PR DESCRIPTION
## Summary
- add targeted pytest coverage for configuration, preprocessing, inference, bucket, utils, and annotation worker helpers
- ensure the test harness can import the project and vendored dependencies without activating the venv manually
- guard the profiling script from instantiating a transformers pipeline during import so tests do not hit the network

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68d08e18e03c832db42faaf5591de861