### PR TITLE
Refactor pipeline to use typed Post models

### DIFF
--- a/app/constants.py
+++ b/app/constants.py
@@ -1,3 +1,16 @@
+"""Centralized constants used across the Reddit meter backend."""
+
 from datetime import timezone
 
+# NOTE:
+# Keeping all temporal calculations in UTC ensures consistent ordering when
+# persisting timestamps to Firestore and JSON archives.
 TIMEZONE = timezone.utc
+
+# Default configuration values used when interacting with Reddit and storing
+# inference metadata. They are defined here to avoid scattering magic numbers
+# and strings throughout the codebase.
+DEFAULT_MAX_POST_AGE_DAYS = 7
+DEFAULT_SENTIMENT_SOURCE = "bert"
+DEFAULT_FETCH_SLEEP_SECONDS = 1
+DEFAULT_COMMENT_AUTHOR_PLACEHOLDER = "[deleted]"

--- a/app/processing/aggregate.py
+++ b/app/processing/aggregate.py
@@ -1,8 +1,13 @@
 # File: app/processing/aggregate.py
+"""Aggregation helpers for computing sentiment summaries from Reddit posts."""
+
 from collections import defaultdict
 import heapq
+from typing import Iterable
 
 import numpy as np
+
+from app.models.post import Post
 
 
 def normalized_softmax(x: np.ndarray, temperature: int) -> np.ndarray:
@@ -12,17 +17,29 @@ def normalized_softmax(x: np.ndarray, temperature: int) -> np.ndarray:
     return e_x / e_x.sum()
 
 
-def compute_sentiment_average(posts: list[dict]) -> dict:
+def _ensure_post(post_data: Post | dict) -> Post:
+    """Coerce dictionaries into :class:`Post` models for uniform handling."""
+
+    if isinstance(post_data, Post):
+        return post_data
+    return Post.model_validate(post_data)
+
+
+def compute_sentiment_average(posts: Iterable[Post | dict]) -> dict:
     """
     Aggregates sentiment scores across all posts.
 
     Args:
-        posts (list): List of posts with 'sentiment' field (dict of 6 emotions).
+        posts (Iterable[Post | dict]): Reddit posts (models or dictionaries) with
+            sentiment predictions attached.
 
     Returns:
         dict: Averaged sentiment values.
     """
-    valid_posts = [p for p in posts if "sentiment" in p and "score" in p]
+    validated_posts = [_ensure_post(p) for p in posts]
+    valid_posts = [
+        p for p in validated_posts if p.sentiment is not None and p.score is not None
+    ]
     if not valid_posts:
         return {}
 
@@ -30,9 +47,12 @@ def compute_sentiment_average(posts: list[dict]) -> dict:
     temperature = 1.5  # Try tuning between 100–5000
 
     filtered = [
-        (i, max(p["score"], 0)) for i, p in enumerate(valid_posts) if p["score"] > 0
+        (i, max(p.score or 0, 0)) for i, p in enumerate(valid_posts) if (p.score or 0) > 0
     ]
-    indices, scores = zip(*filtered) if filtered else ([], [])
+    if not filtered:
+        return {}
+
+    indices, scores = zip(*filtered)
     scores = np.array(scores)
     weights = normalized_softmax(scores, temperature)
 
@@ -41,7 +61,7 @@ def compute_sentiment_average(posts: list[dict]) -> dict:
 
     for i, w in zip(indices, weights):
         post = valid_posts[i]
-        sentiment = post.get("sentiment")
+        sentiment = post.sentiment.model_dump(mode="python") if post.sentiment else {}
         for k, v in sentiment.items():
             contribution = v * w
             weighted_totals[k] += contribution
@@ -60,7 +80,13 @@ def compute_sentiment_average(posts: list[dict]) -> dict:
     return {
         **average,
         "_top_contributor": {
-            k: [entry[2] | {"contribution": entry[0]} for entry in v]
+            k: [
+                {
+                    **entry[2].to_json_dict(),
+                    "contribution": entry[0],
+                }
+                for entry in v
+            ]
             for k, v in top_contributors.items()
         },
     }

--- a/app/storage/firestore.py
+++ b/app/storage/firestore.py
@@ -1,14 +1,18 @@
 # File: app/storage/firestore.py
+"""Firestore repository abstractions for storing Reddit sentiment data."""
+
 import logging
-from datetime import datetime, timezone, timedelta
+from datetime import datetime, timedelta
 from functools import lru_cache
-from typing import Dict
+from typing import Dict, Sequence
 
 from google.api_core.retry import Retry
 from google.cloud import firestore
 
 from app.config import StorageSettings, get_storage_settings
 from app.logging_setup import setup_logging
+from app.models.post import Post
+from app import constants
 
 setup_logging()
 log = logging.getLogger("storage.firestore")
@@ -28,7 +32,7 @@ class FirestoreRepo:
         """
         Save current snapshot of Reddit sentiment to Firestore (sentiment_current/global).
         """
-        now = datetime.now(timezone.utc)
+        now = datetime.now(constants.TIMEZONE)
         try:
             doc_ref = self.db.collection(
                 self.s.CURRENT_SENTIMENT_COLLECTION_NAME
@@ -44,21 +48,37 @@ class FirestoreRepo:
         except Exception:
             log.exception("Failed to save sentiment snapshot")
 
-    def save_post_archive(self, posts: list[dict], timestamp: str = None) -> None:
+    def _prepare_posts_for_storage(
+        self, posts: Sequence[Post | dict], *, json_mode: bool
+    ) -> list[dict]:
+        """Normalize posts into dictionaries for Firestore or JSON archives."""
+
+        serialized = []
+        for post in posts:
+            if isinstance(post, Post):
+                dump = post.to_json_dict() if json_mode else post.to_python_dict()
+            else:
+                dump = post
+            serialized.append(dump)
+        return serialized
+
+    def save_post_archive(self, posts: Sequence[Post | dict], timestamp: str = None) -> None:
         """
         Save all posts from one job into a single Firestore document.
         Document name will be based on UTC timestamp: YYYYMMDDHH
 
         Args:
-            posts (list): List of post dicts (with sentiment).
+            posts (Sequence[Post | dict]): Posts (models or dictionaries) with
+                associated sentiment scores.
             timestamp (str): Optional ISO 8601 timestamp string.
         """
 
         dt = (
             datetime.fromisoformat(timestamp)
             if timestamp
-            else datetime.now(timezone.utc)
+            else datetime.now(constants.TIMEZONE)
         )
+        normalized_posts = self._prepare_posts_for_storage(posts, json_mode=False)
         hour_id = dt.strftime("%Y%m%d%H")  # e.g., 2025062713
         try:
             doc_ref = self.db.collection(self.s.POST_ARCHIVE_COLLECTION_NAME).document(
@@ -66,14 +86,14 @@ class FirestoreRepo:
             )
             doc_ref.set(
                 {
-                    "posts": posts,
-                    "count": len(posts),
+                    "posts": normalized_posts,
+                    "count": len(normalized_posts),
                     "archived_at": dt.isoformat(),
                 },
                 retry=self._retry,
             )
             log.info(
-                f"✅ Archived {len(posts)} posts to Firestore (post_archive/{hour_id})"
+                f"✅ Archived {len(normalized_posts)} posts to Firestore (post_archive/{hour_id})"
             )
         except Exception:
             log.exception("Failed to archive posts")
@@ -83,7 +103,7 @@ class FirestoreRepo:
         Save sentiment snapshot to a timestamped document in Firestore (sentiment_history/<hour>).
         Useful for tracking trends over time.
         """
-        now = datetime.now(timezone.utc)
+        now = datetime.now(constants.TIMEZONE)
         hour_key = now.strftime("%Y-%m-%dT%H")
         payload = {
             **aggregated_sentiment,
@@ -124,7 +144,7 @@ class FirestoreRepo:
         Args:
             num_records (int): The number of data points to retrieve.
         """
-        now = datetime.now(timezone.utc)
+        now = datetime.now(constants.TIMEZONE)
         start_date = now - timedelta(days=num_days)
         try:
             docs = (


### PR DESCRIPTION
## Summary
- introduce shared constants for timezone handling and Reddit fetch defaults
- enhance the Post-related Pydantic models with aliases, validation, and serialization helpers
- refactor the fetcher, runner, aggregation, and Firestore storage layers to operate on Post models and reuse computed timestamps

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e5a7876500832dbffeda4cb7e01a88